### PR TITLE
fix: Set default color so android 4.x do not crash 

### DIFF
--- a/android-exoplayer/src/main/res/drawable/previewseekbar_progress.xml
+++ b/android-exoplayer/src/main/res/drawable/previewseekbar_progress.xml
@@ -5,7 +5,7 @@
             <shape android:shape="rectangle">
                 <size android:height="@dimen/previewseekbar_progress_height" />
                 <corners android:radius="@dimen/previewseekbar_progress_corner_radius" />
-                <solid android:color="?colorPrimary" />
+                <solid android:color="#5353c9" />
             </shape>
         </clip>
     </item>


### PR DESCRIPTION
Set default color so android 4.x do not crash 